### PR TITLE
Cache units to avoid consistent calls to describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Cached units using lru cache to avoid consistant calls to describe
+
 ## [2021.9.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [2022.4.0]
+
 ### Changed
 - Cached units using lru cache to avoid consistant calls to describe
 
@@ -14,5 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - initial release
 
 
-[Unreleased]: https://github.com/wright-group/wright-plans/compare/v2021.9.0...HEAD
+[Unreleased]: https://github.com/wright-group/wright-plans/compare/v2022.4.0...HEAD
+[2022.4.0]: https://github.com/wright-group/wright-plans/compare/v2021.9.0...v2022.4.0
 [2021.9.0]: https://github.com/wright-group/wright-plans/releases/tag/v2021.9.0

--- a/wright_plans/__init__.py
+++ b/wright_plans/__init__.py
@@ -1,6 +1,6 @@
 """Bluesky plans and utilities to provide functionality that the Wright Group needs."""
 
-__version__ = "2021.9.0"
+__version__ = "2022.4.0"
 
 from ._plans import *
 from ._constants import *

--- a/wright_plans/_units.py
+++ b/wright_plans/_units.py
@@ -1,5 +1,7 @@
 __all__ = ["ureg", "get_units"]
 
+from functools import lru_cache
+
 import pint
 
 ureg = pint.UnitRegistry()
@@ -21,6 +23,7 @@ ureg.enable_contexts("spectroscopy")
 
 
 # TODO make sure unit retrival is accurate, robust
+@lru_cache
 def get_units(device, default=None):
     if device is None:
         return default


### PR DESCRIPTION
This was the most common method that caused Waldo to fail, and there is no need to contact the daemon/device more than once, so avoid recalculating units

@kelsonoram 