### PR TITLE
Suggested revision of | vs 'or' logic for dictionaries/sets. 

### DIFF
--- a/wright_plans/attune.py
+++ b/wright_plans/attune.py
@@ -244,7 +244,7 @@ def run_intensity(detectors, opa, motor, width, npts, spectrometer, *, md=None):
             True,
             {motor: {"method": "scan", "width": width, "npts": npts}},
             spectrometer,
-            md=local_md | md,
+            md=local_md or md,
         )
     )
 


### PR DESCRIPTION
…ged to the 'or' operator. Note, only one of the | operations was changed, but if this is a correct change, then the other throughout the code should be reevaluated. Not sure if this is due to python 3.6-3.7 dictionary/set redefinition.